### PR TITLE
Add timestamps

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,9 @@ P1Reader.prototype.parsePackage = function(rawData) {
                 data.electricity.currentlyReturning = parseInt(res[2].replace('.', '') + '0');
                 break;
             case '24.3.0':
-                data.gas.date = new Date("20" + res[2].substring(0,2), res[2].substring(2,4), res[2].substring(4,6), res[2].substring(6,8), res[2].substring(8,10), res[2].substring(10,12), 0);
+                var dateString = "20" + res[2].substring(0,2) + "-" + res[2].substring(2,4) + "-" + res[2].substring(4,6) + " ";
+                    dateString += res[2].substring(6,8) + ":" + res[2].substring(8,10) + ":" + res[2].substring(10,12);
+                data.gas.date = new Date(dateString);
                 data.gas.used = lines[l+1].replace(/[\(\)]/g, '').trim();
                 break;
         }

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ P1Reader.prototype.parsePackage = function(rawData) {
 
     var data = { "electricity": {}, "gas": {} };
     data.electricity.date = new Date();
+    data.electricity.timestamp = Math.floor(data.electricity.date.getTime() / 1000);
     var lines = rawData.split("\r\n");
     // Not a full package (not enough lines)
     if(lines.length < 19) {
@@ -101,6 +102,7 @@ P1Reader.prototype.parsePackage = function(rawData) {
                 var dateString = "20" + res[2].substring(0,2) + "-" + res[2].substring(2,4) + "-" + res[2].substring(4,6) + " ";
                     dateString += res[2].substring(6,8) + ":" + res[2].substring(8,10) + ":" + res[2].substring(10,12);
                 data.gas.date = new Date(dateString);
+                data.gas.timestamp = Math.floor(data.gas.date.getTime() / 1000);
                 data.gas.used = lines[l+1].replace(/[\(\)]/g, '').trim();
                 break;
         }


### PR DESCRIPTION
It would be nice to have timestamps included, since they contain no timezone representation and can be parsed by other software after persistence (without having to parse the original string)

Based upon https://github.com/Martijn02/node-p1reader/pull/2
